### PR TITLE
自動再起動用シェルスクリプト

### DIFF
--- a/reboot.sh
+++ b/reboot.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+cd ~/project_dir
+
+GIT_OUTPUT_MESSAGE=`git pull`
+ALREADY_MESSAGE="Already up to date."
+
+source app/.env
+
+if [ "$GIT_OUTPUT_MESSAGE" != "$ALREADY_MESSAGE" ]; then
+    curl \
+        -H "Content-Type: application/json" \
+        -X POST \
+        -d "{\"content\": \"$GIT_OUTPUT_MESSAGE\"}" \
+        $DISCORD_WEBHOOK_URL_REBOOT_LOG
+
+    if [[ "$GIT_OUTPUT_MESSAGE" =~ "error" ]]; then
+        exit 1
+    fi
+
+    docker-compose up -d
+    curl \
+        -H "Content-Type: application/json" \
+        -X POST \
+        -d "{\"content\": \"再起動しました。"}" \
+        $DISCORD_WEBHOOK_URL_REBOOT_LOG
+
+
+fi


### PR DESCRIPTION
git pullした時の出力結果により実行内容を選定

Already -> 差分が無いので何もしない
error -> logには出すが、コンテナの再起動は行わない
通常出力 -> 出力結果をそのまま送信し、コンテナの再起動を行う